### PR TITLE
[Feat] 예약 내역 페이지 스켈레톤 구현 및 보완

### DIFF
--- a/src/app/(header)/(narrow-view)/reservation-list/_components/reservation-item/page.tsx
+++ b/src/app/(header)/(narrow-view)/reservation-list/_components/reservation-item/page.tsx
@@ -33,7 +33,7 @@ function ReservationItem({ item }: { item: TReservationItem }) {
       </div>
       <div className={styles.priceInfo}>
         <Text fontSize="md" fontWeight="bold">
-          {`${item.order_price}원`}
+          {`${item.order_price.toLocaleString()}원`}
         </Text>
       </div>
     </div>

--- a/src/app/(header)/(narrow-view)/reservation-list/_components/reservation-item/reservationItem.module.scss
+++ b/src/app/(header)/(narrow-view)/reservation-list/_components/reservation-item/reservationItem.module.scss
@@ -5,11 +5,11 @@
   height: 8.125rem;
 
   border: 1px solid $gray;
-  padding: 0.5rem 0.2rem 0.5rem 0.7rem;
+  padding: 0.5rem 0.5rem 0.5rem 0.7rem;
   box-sizing: border-box;
 
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
 }
 .itemInfo {
   width: 35.625rem;

--- a/src/app/(header)/(narrow-view)/reservation-list/_components/reservation-skeleton/index.tsx
+++ b/src/app/(header)/(narrow-view)/reservation-list/_components/reservation-skeleton/index.tsx
@@ -1,0 +1,24 @@
+import Skeleton from '@/components/layouts/skeleton';
+import styles from '../reservation-item/reservationItem.module.scss';
+function ReservationSkeleton() {
+  return (
+    <div className={styles.reservationItem}>
+      <div className={styles.itemInfo}>
+        <Skeleton width={300} height={20} borderRadius={4} />
+        <div className={styles.imageInfo}>
+          <Skeleton width={80} height={80} borderRadius={8} />
+          <div className={styles.detailInfo}>
+            <Skeleton width={100} height={10} borderRadius={4} />
+            <Skeleton width={100} height={10} borderRadius={4} />
+            <Skeleton width={100} height={10} borderRadius={4} />
+          </div>
+        </div>
+      </div>
+      <div className={styles.priceInfo}>
+        <Skeleton width={150} height={20} borderRadius={4} />
+      </div>
+    </div>
+  );
+}
+
+export default ReservationSkeleton;

--- a/src/app/(header)/(narrow-view)/reservation-list/reservationList.tsx
+++ b/src/app/(header)/(narrow-view)/reservation-list/reservationList.tsx
@@ -6,13 +6,19 @@ import styles from './reservationList.module.scss';
 import useReservationList from '@/hooks/reservation-list/useReservationList';
 import Text from '@/components/atoms/text';
 import Loader from '@/components/layouts/loader';
+import ReservationSkeleton from './_components/reservation-skeleton';
 
 function ReservationList() {
   const { reservationItems, fetchNextPage, hasNextPage, isError, isLoading } =
     useReservationList();
 
   if (isLoading) {
-    return <Loader size="sm" />;
+    const skeletonArray = new Array(5).fill('');
+    return (
+      <section className={styles.reservationItemContainer}>
+        {skeletonArray?.map((_, index) => <ReservationSkeleton key={index} />)}
+      </section>
+    );
   }
 
   if (isError) {

--- a/src/app/(header)/(narrow-view)/reservation-list/reservationList.tsx
+++ b/src/app/(header)/(narrow-view)/reservation-list/reservationList.tsx
@@ -12,7 +12,7 @@ function ReservationList() {
     useReservationList();
 
   if (isLoading) {
-    return <Loader />;
+    return <Loader size="sm" />;
   }
 
   if (isError) {
@@ -41,7 +41,7 @@ function ReservationList() {
       scrollThreshold={0.95}
       next={fetchNextPage}
       hasMore={hasNextPage ?? false}
-      loader={<h4>Loading...</h4>}>
+      loader={<Loader size="sm" />}>
       <section className={styles.reservationItemContainer}>
         {reservationItems?.map((item, index) => (
           <ReservationItem key={index} item={item} />

--- a/src/components/layouts/loader/index.tsx
+++ b/src/components/layouts/loader/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styles from './loader.module.scss';
 
-function Loader() {
+function Loader({ size = 'lg' }) {
   return (
-    <div className={styles.loader}>
-      <div className={styles.spinner}></div>
+    <div className={`${styles['loader']} ${styles[size]}`}>
+      <div className={`${styles['spinner']} ${styles[size]}`}></div>
     </div>
   );
 }

--- a/src/components/layouts/loader/index.tsx
+++ b/src/components/layouts/loader/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styles from './loader.module.scss';
+import { TLoader } from './loaderType';
 
-function Loader({ size = 'lg' }) {
+function Loader({ size = 'lg' }: TLoader) {
   return (
     <div className={`${styles['loader']} ${styles[size]}`}>
       <div className={`${styles['spinner']} ${styles[size]}`}></div>

--- a/src/components/layouts/loader/loader.module.scss
+++ b/src/components/layouts/loader/loader.module.scss
@@ -3,16 +3,27 @@
 .loader {
   display: flex;
   justify-content: center;
-
-  padding: 3rem;
-  height: 100%;
+  &.lg {
+    padding: 3rem;
+  }
+  &.sm {
+    padding: 2rem;
+  }
   .spinner {
-    $size: 4rem;
-    border: 1rem solid $gray;
-    border-top: 16px solid $highlight;
+    &.lg {
+      $size: 4rem;
+      width: $size;
+      height: $size;
+    }
+    &.sm {
+      $size: 2rem;
+      width: $size;
+      height: $size;
+    }
+
+    border: 0.5rem solid $gray;
+    border-top: 0.5rem solid $highlight;
     border-radius: 50%;
-    width: $size;
-    height: $size;
     animation: spin 2s linear infinite;
   }
 

--- a/src/components/layouts/loader/loaderType.ts
+++ b/src/components/layouts/loader/loaderType.ts
@@ -1,0 +1,3 @@
+export type TLoader = {
+  size: 'lg' | 'sm';
+};

--- a/src/components/layouts/skeleton/index.tsx
+++ b/src/components/layouts/skeleton/index.tsx
@@ -1,0 +1,22 @@
+import { pxToRem } from '@/utils/pxToRem';
+import { TSkeleton } from './skeletonType';
+import styles from './skeleton.module.scss';
+
+/**
+ * @params width는 px 단위로 작성한다.
+ * @params height은 px 단위로 작성한다.
+ * @params borderRadius는 px 단위로 작성한다.
+ */
+function Skeleton({ width, height, borderRadius }: TSkeleton) {
+  return (
+    <div
+      style={{
+        width: `${pxToRem(width)}rem`,
+        height: `${pxToRem(height)}rem`,
+        borderRadius: `${pxToRem(borderRadius)}rem`,
+      }}
+      className={styles.skeleton}></div>
+  );
+}
+
+export default Skeleton;

--- a/src/components/layouts/skeleton/skeleton.module.scss
+++ b/src/components/layouts/skeleton/skeleton.module.scss
@@ -1,0 +1,32 @@
+@import '@styles/_variables.scss';
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: 10px;
+  background-color: $gray;
+}
+.skeleton::after {
+  content: '';
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-image: linear-gradient(
+    270deg,
+    rgba(255, 255, 255, 0),
+    $blackAlpha200,
+    rgba(255, 255, 255, 0)
+  );
+  transform: translateX(-100%);
+  animation: skeleton-loader 2s infinite;
+}
+@keyframes skeleton-loader {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/src/components/layouts/skeleton/skeleton.stories.tsx
+++ b/src/components/layouts/skeleton/skeleton.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import Skeleton from '.';
+
+const meta = {
+  title: 'components/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+    },
+    componentSubtitle:
+      'Skeleton은 각 페이지에서 공통적으로 사용될 Skeleton 컴포넌트입니다. ',
+    docs: {
+      description: {
+        component: `
+- width값으로 px 단위의 number을 할 수 있습니다.\n
+- height값으로 px 단위의 number을 할 수 있습니다.\n
+-borderRadius값으로 px 단위의 number을 할 수 있습니다.\n
+
+`,
+      },
+    },
+  },
+  argTypes: {
+    width: {
+      description: 'Skeleton의 Width를 설정합니다.',
+      table: {
+        type: { summary: 'SkeletonWidth' },
+        defaultValue: { summary: '100' },
+      },
+      control: {
+        type: 'text',
+      },
+    },
+    height: {
+      description: 'Skeleton의 Height를 설정합니다.',
+      table: {
+        type: { summary: 'SkeletonHeight' },
+        defaultValue: { summary: '100' },
+      },
+      control: {
+        type: 'text',
+      },
+    },
+    borderRadius: {
+      description: 'Skeleton의 borderRadius를 설정합니다.',
+      table: {
+        type: { summary: 'SkeletonBorderRadius' },
+        defaultValue: { summary: '10' },
+      },
+      control: {
+        type: 'text',
+      },
+    },
+  },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+
+export const defaultSkeleton: StoryObj<typeof Skeleton> = {
+  parameters: {
+    docs: {
+      description: {
+        story: '기본으로 사용되는 default Skeleton입니다.',
+      },
+    },
+  },
+  render: (args) => <Skeleton {...args}></Skeleton>,
+};

--- a/src/components/layouts/skeleton/skeletonType.ts
+++ b/src/components/layouts/skeleton/skeletonType.ts
@@ -1,0 +1,5 @@
+export type TSkeleton = {
+  width: number;
+  height: number;
+  borderRadius: number;
+};

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -5,15 +5,14 @@ $highlight: #726bd7;
 $background-gray: #f5f5f5;
 $error: #ff6565;
 $success: #38a169;
-$gray400:#cccccc;
-$gray200:#e5e5e5;
-$gray300:#e5e5e5;
-$blackAlpha100:#000000;
-$red100:#ff6565;
-$red200:#e53e3e;
-$green:#38a169;
-$highlight:#726bd7;
-$black:#222222;
-$gray100:#f5f5f5;
-
-
+$gray400: #cccccc;
+$gray200: #e5e5e5;
+$gray300: #e5e5e5;
+$blackAlpha100: #000000;
+$red100: #ff6565;
+$red200: #e53e3e;
+$green: #38a169;
+$highlight: #726bd7;
+$black: #222222;
+$gray100: #f5f5f5;
+$blackAlpha200: rgba(255, 255, 255, 0.5);

--- a/src/utils/pxToRem.ts
+++ b/src/utils/pxToRem.ts
@@ -1,0 +1,3 @@
+export const pxToRem = (px: number): number => {
+  return px / 16;
+};


### PR DESCRIPTION
### ⛳️ Task

- [X] loader 컴포넌트 커스터마이징
- [X] 예약내역 페이지 가격 콤마 추가
- [X] 스켈레톤 컴포넌트 구현 및 예약 내역 페이지 스켈레톤 적용

### ✍️ Note

예약 내역 페이지 보완을 했습니다
먼저 스켈레톤 공통 컴포넌트 구현 후 예약 내역 페이지에 적용했습니다 스켈레톤 공통 컴포넌트는 width,height,borderRadius 속성을 전달해 각자 페이지에서 사용하면 될 것 같습니다
사실 skeleton 라이브러리들이 많아서 라이브러리를 사용할까?라는고민을 하게 되었는데 유지 보수를 위해 프로젝트에 최대한 의존성을 줄이는 것이 좋다고 생각해서 라이브러리를 사용하지 않았습니다.스켈레톤 코드가 어렵지도 않고요!

또한 선파님이 만드신 loader 컴포넌트는 예약 내역 페이지에서 무한 스크롤 로딩에 사용하기엔 다소 크기가 커서 커스터마이징을 거쳤습니다. 기본값을 지정해줘서 현재 로더를 사용하고 있는 페이지에서는 변경하실 부분은 없습니다


### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
